### PR TITLE
Make Completion Work Better

### DIFF
--- a/cmd/kubectl-unikorn/main.go
+++ b/cmd/kubectl-unikorn/main.go
@@ -17,8 +17,10 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -30,26 +32,78 @@ import (
 	kubernetesv1 "github.com/unikorn-cloud/kubernetes/pkg/apis/unikorn/v1alpha1"
 	regionv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 
-	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+func getScheme() (*runtime.Scheme, error) {
+	schemes := []func(*runtime.Scheme) error{
+		k8sscheme.AddToScheme,
+		computev1.AddToScheme,
+		identityv1.AddToScheme,
+		kubernetesv1.AddToScheme,
+		regionv1.AddToScheme,
+	}
+
+	scheme := runtime.NewScheme()
+
+	for _, s := range schemes {
+		if err := s(scheme); err != nil {
+			return nil, err
+		}
+	}
+
+	return scheme, nil
+}
+
+func getClient(ctx context.Context) (client.Client, error) {
+	path := filepath.Join(homedir.HomeDir(), ".kube", "config")
+
+	config, err := clientcmd.BuildConfigFromFlags("", path)
+	if err != nil {
+		return nil, err
+	}
+
+	scheme, err := getScheme()
+	if err != nil {
+		return nil, err
+	}
+
+	cache, err := cache.New(config, cache.Options{Scheme: scheme})
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		_ = cache.Start(ctx)
+	}()
+
+	cache.WaitForCacheSync(ctx)
+
+	options := client.Options{
+		Scheme: scheme,
+		Cache: &client.CacheOptions{
+			Reader:       cache,
+			Unstructured: false,
+		},
+	}
+
+	client, err := client.New(config, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
 func main() {
-	if err := computev1.AddToScheme(scheme.Scheme); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	if err := identityv1.AddToScheme(scheme.Scheme); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	if err := kubernetesv1.AddToScheme(scheme.Scheme); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	if err := regionv1.AddToScheme(scheme.Scheme); err != nil {
+	client, err := getClient(context.Background())
+	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
@@ -59,7 +113,7 @@ func main() {
 		Short: "Unikorn kubectl plugin",
 	}
 
-	factory := factory.NewFactory()
+	factory := factory.NewFactory(client)
 	factory.AddFlags(cmd.PersistentFlags())
 
 	if err := factory.RegisterCompletionFunctions(cmd); err != nil {

--- a/pkg/cmd/flags/flags.go
+++ b/pkg/cmd/flags/flags.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/spf13/pflag"
+
 	"github.com/unikorn-cloud/kubectl-unikorn/pkg/cmd/errors"
 )
 
@@ -46,4 +48,22 @@ func (v HostnameVar) String() string {
 
 func (v HostnameVar) Type() string {
 	return "domainname"
+}
+
+type UnikornFlags struct {
+	IdentityNamespace string
+	RegionNamespace   string
+}
+
+func (o *UnikornFlags) AddFlags(f *pflag.FlagSet) {
+	f.StringVar(&o.IdentityNamespace, "identity-namespace", "unikorn-identity", "Identity service namespace")
+	f.StringVar(&o.RegionNamespace, "region-namespace", "unikorn-region", "Region service namespace")
+}
+
+type OrganizationFlags struct {
+	OrganizationName string
+}
+
+func (o *OrganizationFlags) AddFlags(f *pflag.FlagSet) {
+	f.StringVar(&o.OrganizationName, "organization", "", "Organization to scope to")
 }


### PR DESCRIPTION
Quit messing with low level interfaces and start using controller runtime's client.  Add in Unikorn specific global flags, and make the completion functions search based on them, rather than the old global namespace, which isn't really applicapble to a Unikorn deployment.