### PR TITLE
Make Completion Work Even Better

### DIFF
--- a/cmd/kubectl-unikorn/main.go
+++ b/cmd/kubectl-unikorn/main.go
@@ -17,103 +17,23 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 
-	computev1 "github.com/unikorn-cloud/compute/pkg/apis/unikorn/v1alpha1"
-	identityv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/kubectl-unikorn/pkg/cmd/create"
 	"github.com/unikorn-cloud/kubectl-unikorn/pkg/cmd/factory"
 	"github.com/unikorn-cloud/kubectl-unikorn/pkg/cmd/get"
-	kubernetesv1 "github.com/unikorn-cloud/kubernetes/pkg/apis/unikorn/v1alpha1"
-	regionv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	k8sscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
-
-	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func getScheme() (*runtime.Scheme, error) {
-	schemes := []func(*runtime.Scheme) error{
-		k8sscheme.AddToScheme,
-		computev1.AddToScheme,
-		identityv1.AddToScheme,
-		kubernetesv1.AddToScheme,
-		regionv1.AddToScheme,
-	}
-
-	scheme := runtime.NewScheme()
-
-	for _, s := range schemes {
-		if err := s(scheme); err != nil {
-			return nil, err
-		}
-	}
-
-	return scheme, nil
-}
-
-func getClient(ctx context.Context) (client.Client, error) {
-	path := filepath.Join(homedir.HomeDir(), ".kube", "config")
-
-	config, err := clientcmd.BuildConfigFromFlags("", path)
-	if err != nil {
-		return nil, err
-	}
-
-	scheme, err := getScheme()
-	if err != nil {
-		return nil, err
-	}
-
-	cache, err := cache.New(config, cache.Options{Scheme: scheme})
-	if err != nil {
-		return nil, err
-	}
-
-	go func() {
-		_ = cache.Start(ctx)
-	}()
-
-	cache.WaitForCacheSync(ctx)
-
-	options := client.Options{
-		Scheme: scheme,
-		Cache: &client.CacheOptions{
-			Reader:       cache,
-			Unstructured: false,
-		},
-	}
-
-	client, err := client.New(config, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return client, nil
-}
-
 func main() {
-	client, err := getClient(context.Background())
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
 	cmd := &cobra.Command{
 		Use:   "kubectl-unikorn",
 		Short: "Unikorn kubectl plugin",
 	}
 
-	factory := factory.NewFactory(client)
+	factory := factory.NewFactory()
 	factory.AddFlags(cmd.PersistentFlags())
 
 	if err := factory.RegisterCompletionFunctions(cmd); err != nil {

--- a/pkg/cmd/create/create_group.go
+++ b/pkg/cmd/create/create_group.go
@@ -265,7 +265,10 @@ func createGroup(factory *factory.Factory) *cobra.Command {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 
-			client := factory.Client()
+			client, err := factory.Client()
+			if err != nil {
+				return err
+			}
 
 			if err := o.validate(ctx, client); err != nil {
 				return err

--- a/pkg/cmd/create/create_organization.go
+++ b/pkg/cmd/create/create_organization.go
@@ -146,7 +146,10 @@ func createOrganization(factory *factory.Factory) *cobra.Command {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 
-			client := factory.Client()
+			client, err := factory.Client()
+			if err != nil {
+				return err
+			}
 
 			if err := o.validate(ctx, client); err != nil {
 				return err

--- a/pkg/cmd/create/create_user.go
+++ b/pkg/cmd/create/create_user.go
@@ -95,7 +95,10 @@ func createUser(factory *factory.Factory) *cobra.Command {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 
-			client := factory.Client()
+			client, err := factory.Client()
+			if err != nil {
+				return err
+			}
 
 			if err := o.validate(ctx, client); err != nil {
 				return err

--- a/pkg/cmd/flags/flags.go
+++ b/pkg/cmd/flags/flags.go
@@ -19,10 +19,13 @@ package flags
 import (
 	"fmt"
 	"net/url"
+	"path/filepath"
 
 	"github.com/spf13/pflag"
 
 	"github.com/unikorn-cloud/kubectl-unikorn/pkg/cmd/errors"
+
+	"k8s.io/client-go/util/homedir"
 )
 
 type HostnameVar string
@@ -51,11 +54,13 @@ func (v HostnameVar) Type() string {
 }
 
 type UnikornFlags struct {
+	Kubeconfig        string
 	IdentityNamespace string
 	RegionNamespace   string
 }
 
 func (o *UnikornFlags) AddFlags(f *pflag.FlagSet) {
+	f.StringVar(&o.Kubeconfig, "kubeconfig", filepath.Join(homedir.HomeDir(), ".kube", "config"), "Kubernetes configuration file")
 	f.StringVar(&o.IdentityNamespace, "identity-namespace", "unikorn-identity", "Identity service namespace")
 	f.StringVar(&o.RegionNamespace, "region-namespace", "unikorn-region", "Region service namespace")
 }

--- a/pkg/cmd/get/get_user.go
+++ b/pkg/cmd/get/get_user.go
@@ -196,7 +196,10 @@ func getUser(factory *factory.Factory) *cobra.Command {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 
-			client := factory.Client()
+			client, err := factory.Client()
+			if err != nil {
+				return err
+			}
 
 			if err := o.validate(ctx, client); err != nil {
 				return err


### PR DESCRIPTION
Make it so that the Kubeconfig path can be completed, make client creation lazy so we can pick up said kubeconfig, and add completion functions to allow namespace overrides.