### PR TITLE
Respect KUBECONFIG environment variable if set

### DIFF
--- a/pkg/factory/factory.go
+++ b/pkg/factory/factory.go
@@ -18,7 +18,6 @@ package factory
 
 import (
 	"context"
-	"path/filepath"
 	"slices"
 
 	"github.com/spf13/cobra"
@@ -36,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -77,7 +75,8 @@ func NewFactory() *Factory {
 }
 
 func (f *Factory) AddFlags(flags *pflag.FlagSet) {
-	flags.StringVar(&f.UnikornFlags.Kubeconfig, "kubeconfig", filepath.Join(homedir.HomeDir(), ".kube", "config"), "Kubernetes configuration file")
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	flags.StringVar(&f.UnikornFlags.Kubeconfig, "kubeconfig", loadingRules.GetDefaultFilename(), "Kubernetes configuration file")
 	flags.StringVar(&f.UnikornFlags.IdentityNamespace, "identity-namespace", "unikorn-identity", "Identity service namespace")
 	flags.StringVar(&f.UnikornFlags.RegionNamespace, "region-namespace", "unikorn-region", "Region service namespace")
 }


### PR DESCRIPTION
Fix the behaviour of this client so it'll honour KUBECONFIG if set, otherwise load from a file as specified by the --kubeconfig flag.